### PR TITLE
Add Lazy<T> spec and catalog scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `Catalog::scope` and `Catalog::current` allow setting and accessing a "current" catalog in a task-local context
+  - Requires new `tokio` crate feature
+- `Lazy<T>` injection spec that delays the creation of a value until it's requested
+  - Can be used to delay initialization of expensive values that are rarely used
+  - Can be used in combination with `Catalog::scope` to inject values registered dynamically
+
 ## [0.9.3] - 2024-12-06
 ### Changed
 - Upgraded to `thiserror v2` dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "dill-impl",
  "multimap",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ assert_eq!(inst.test(), "aimpl::bimpl");
 - Injection specs:
   - `OneOf` - expects a single implementation of a given interface
   - `AllOf` - returns a collection of all implementations on a given interface
-  - `Maybe<Spec>` - Returns `None` if inner `Spec` cannot be resolved
+  - `Maybe<Spec>` - returns `None` if inner `Spec` cannot be resolved
+  - `Lazy<Spec>` - injects an object that delays the creation of value until it is requested
 - Component scopes:
   - `Transient` (default) - a new instance is created for every invocation
   - `Singleton` - an instance is created upon first use and then reused for the rest of calls
@@ -89,6 +90,7 @@ assert_eq!(inst.test(), "aimpl::bimpl");
 - By value injection of `Clone` types
 - `Catalog` can be self-injected
 - Chaining of `Catalog`s allows adding values dynamically (e.g. in middleware chains like `tower`)
+- `Catalog` can be scoped within a `tokio` task as "current" to override the source of `Lazy`ly injected values
 
 
 # Design Principles
@@ -127,7 +129,6 @@ assert_eq!(inst.test(), "aimpl::bimpl");
   - task
   - catalog?
 - thread safety
-- lazy values
 - externally defined types
 - custom builders
 - error handling

--- a/dill-impl/src/lib.rs
+++ b/dill-impl/src/lib.rs
@@ -362,6 +362,12 @@ fn implement_arg(
             }
             _ => unimplemented!("Currently only Option<Arc<Iface>> is supported"),
         },
+        InjectionType::Lazy { element } => match element.as_ref() {
+            InjectionType::Arc { inner } => {
+                quote! { ::dill::specs::Lazy::<::dill::OneOf::<#inner>>::check(cat) }
+            }
+            _ => unimplemented!("Currently only Option<Arc<Iface>> is supported"),
+        },
         InjectionType::Vec { item } => match item.as_ref() {
             InjectionType::Arc { inner } => quote! { ::dill::AllOf::<#inner>::check(cat) },
             _ => unimplemented!("Currently only Vec<Arc<Iface>> is supported"),
@@ -386,6 +392,12 @@ fn implement_arg(
                 quote! { ::dill::Maybe::<::dill::OneOf::<#inner>>::get(cat)? }
             }
             _ => unimplemented!("Currently only Option<Arc<Iface>> is supported"),
+        },
+        InjectionType::Lazy { element } => match element.as_ref() {
+            InjectionType::Arc { inner } => {
+                quote! { ::dill::specs::Lazy::<::dill::OneOf::<#inner>>::get(cat)? }
+            }
+            _ => unimplemented!("Currently only Lazy<Arc<Iface>> is supported"),
         },
         InjectionType::Vec { item } => match item.as_ref() {
             InjectionType::Arc { inner } => quote! { ::dill::AllOf::<#inner>::get(cat)? },

--- a/dill/Cargo.toml
+++ b/dill/Cargo.toml
@@ -12,7 +12,20 @@ keywords = { workspace = true }
 include = { workspace = true }
 edition = { workspace = true }
 
+
+[features]
+default = []
+tokio = ["dep:tokio"]
+
+
 [dependencies]
 dill-impl = { workspace = true }
 thiserror = "2"
 multimap = "0.10"
+
+# Optional
+tokio = { optional = true, version = "1", default-features = false }
+
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/dill/src/builder.rs
+++ b/dill/src/builder.rs
@@ -235,27 +235,27 @@ where
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
-pub(crate) struct Lazy<Fct, Impl>
+pub(crate) struct LazyBuilder<Fct, Impl>
 where
     Fct: FnOnce() -> Impl,
     Impl: 'static + Send + Sync,
 {
-    state: Mutex<LazyState<Fct, Impl>>,
+    state: Mutex<LazyBuilderState<Fct, Impl>>,
 }
 
-struct LazyState<Fct, Impl> {
+struct LazyBuilderState<Fct, Impl> {
     factory: Option<Fct>,
     instance: Option<Arc<Impl>>,
 }
 
-impl<Fct, Impl> Lazy<Fct, Impl>
+impl<Fct, Impl> LazyBuilder<Fct, Impl>
 where
     Fct: FnOnce() -> Impl,
     Impl: 'static + Send + Sync,
 {
     pub fn new(factory: Fct) -> Self {
         Self {
-            state: Mutex::new(LazyState {
+            state: Mutex::new(LazyBuilderState {
                 factory: Some(factory),
                 instance: None,
             }),
@@ -263,7 +263,7 @@ where
     }
 }
 
-impl<Fct, Impl> Builder for Lazy<Fct, Impl>
+impl<Fct, Impl> Builder for LazyBuilder<Fct, Impl>
 where
     Fct: FnOnce() -> Impl + Send + Sync,
     Impl: 'static + Send + Sync,
@@ -289,7 +289,7 @@ where
     }
 }
 
-impl<Fct, Impl> TypedBuilder<Impl> for Lazy<Fct, Impl>
+impl<Fct, Impl> TypedBuilder<Impl> for LazyBuilder<Fct, Impl>
 where
     Fct: FnOnce() -> Impl + Send + Sync,
     Impl: 'static + Send + Sync,

--- a/dill/src/catalog_builder.rs
+++ b/dill/src/catalog_builder.rs
@@ -97,7 +97,7 @@ impl CatalogBuilder {
         Fct: FnOnce() -> Impl + Send + Sync + 'static,
         Impl: Send + Sync + 'static,
     {
-        self.add_builder(Lazy::new(factory));
+        self.add_builder(LazyBuilder::new(factory));
         self
     }
 

--- a/dill/src/lazy.rs
+++ b/dill/src/lazy.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use crate::InjectionError;
+
+/// Represents a value whose construction is delayed upon request rather than
+/// resolved from the catalog immediately. This is often useful in cases when
+/// some expensive type is used rarely, thus it's benefitial to only construct
+/// it on-demand.
+///
+/// When instance is requested, this type will first attempt to resolve it using
+/// [`crate::Catalog::current`] and will fall back to the catalog instance used
+/// to create the `Lazy<T>`. This means that `Lazy<T>` can be used to access
+/// values that are dynamically added into a chain of catalogs and may not be
+/// present when the `Lazy<T>` itself is injected.
+///
+/// Note that this style of injection still respects the component's control
+/// over its own lifetime via [`crate::Scope`]. So its recommended to use
+/// [`Self::get`] liberally and release the instances ASAP without attempting
+/// to cache them.
+///
+/// See also:
+/// - [`crate::Catalog::builder_chained`]
+/// - [`crate::Catalog::scope`]
+/// - [`crate::Catalog::current`]
+///
+/// ### Examples
+///
+/// ```
+/// #[dill::component]
+/// struct A;
+///
+/// impl A {
+///     fn test(&self) -> String {
+///         "A".into()
+///     }
+/// }
+///
+/// #[dill::component]
+/// struct B {
+///     lazy_a: dill::Lazy<std::sync::Arc<A>>,
+/// }
+/// impl B {
+///     fn test(&self) -> String {
+///         // A is created on-demand during this call
+///         let a = self.lazy_a.get().unwrap();
+///         a.test()
+///     }
+/// }
+///
+/// let cat = dill::Catalog::builder()
+///     .add::<A>()
+///     .add::<B>()
+///     .build();
+/// ```
+#[derive(Clone)]
+pub struct Lazy<T> {
+    factory: Arc<dyn Fn() -> Result<T, InjectionError> + Send + Sync>,
+}
+
+impl<T> std::fmt::Debug for Lazy<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Lazy").finish_non_exhaustive()
+    }
+}
+
+impl<T> Lazy<T> {
+    pub fn new(f: impl Fn() -> Result<T, InjectionError> + Send + Sync + 'static) -> Self {
+        Self {
+            factory: Arc::new(f),
+        }
+    }
+
+    pub fn get(&self) -> Result<T, InjectionError> {
+        (self.factory)()
+    }
+}

--- a/dill/src/lib.rs
+++ b/dill/src/lib.rs
@@ -164,25 +164,21 @@
 //! assert_eq!(inst.url(), "http://foo:8080");
 //! ```
 
-pub use dill_impl::*;
-
 mod builder;
-pub use builder::*;
-
-mod catalog_builder;
-pub use catalog_builder::*;
-
 mod catalog;
-pub use catalog::*;
-
+mod catalog_builder;
 mod errors;
-pub use errors::*;
-
-mod specs;
-pub use specs::*;
-
+mod lazy;
 mod scopes;
-pub use scopes::*;
-
+pub mod specs;
 mod typecast_builder;
+
+pub use builder::*;
+pub use catalog::*;
+pub use catalog_builder::*;
+pub use dill_impl::*;
+pub use errors::*;
+pub use lazy::Lazy;
+pub use scopes::*;
+pub use specs::*;
 pub use typecast_builder::*;


### PR DESCRIPTION
Introduces a new type of injectable:
```rust
struct Impl {
  lazy_a: Lazy<Arc<dyn A>>,
}
```
`Lazy<T>` delays the value creation from catalog until it's requested:
```rust
let a = self.lazy_a.get()?;
```
Lifetime of `A` in this case is still controlled by the `Scope` (e.g. could be a `Singleton` and reuse an instance), so user code is expected to `get()` instances and let them drop ASAP after use.

Lazy values will be created using a **cloned instance** of a catalog that `Lazy<T>` stores during its instantiation alongside the `Impl` instance.

In cases like DB transactions this is not great, as we may need a flexibility to add transaction dynamically into a chained catalog **after** the `Lazy<Transaction>` was created, yet `Lazy` will be bound to an instance of `Catalog` that doesn't have the transaction.

To solve this I'm introducing the idea of a task-local current catalog:

```rust
catalog.scope(async move {
  // Lazy::get() will use scoped catalog
  // Catalog::current() to access catalog in current scope
}).await
``` 