### PR TITLE
Experiment: autobinding for builder interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- `CatalogBuilder::add_builder()` method will automatically register interfaces (`#[interface(dyn Iface)]`) for `#[component]`
+
 ## [0.12.4] - 2025-03-26
 ### Fixed
-- Supress `clippy::too_many_arguments` warning in generated functions.
+- Suppress `clippy::too_many_arguments` warning in generated functions.
 
 ## [0.12.3] - 2025-03-26
 ### Changed

--- a/dill-impl/src/lib.rs
+++ b/dill-impl/src/lib.rs
@@ -284,10 +284,6 @@ fn implement_builder(
 
                 fn register(cat: &mut ::dill::CatalogBuilder) {
                     cat.add_builder(Self::builder());
-
-                    #(
-                        cat.bind::<#interfaces, #impl_type>();
-                    )*
                 }
 
                 fn builder() -> Self::Builder {
@@ -395,8 +391,16 @@ fn implement_builder(
             }
         }
 
+        impl ::dill::TypedBuilderInterfaceBinder for #builder_name {
+            fn bind_interfaces(cat: &mut ::dill::CatalogBuilder) {
+                #(
+                    cat.bind::<#interfaces, #impl_type>();
+                )*
+            }
+        }
+
         #(
-            // Allows casting TypedBuider<T> into TypedBuilder<dyn I> for all declared interfaces
+            // Allows casting TypedBuilder<T> into TypedBuilder<dyn I> for all declared interfaces
             impl ::dill::TypedBuilderCast<#interfaces> for #builder_name
             {
                 fn cast(self) -> impl ::dill::TypedBuilder<#interfaces> {

--- a/dill/src/catalog_builder.rs
+++ b/dill/src/catalog_builder.rs
@@ -44,7 +44,7 @@ impl CatalogBuilder {
 
     /// Registers a component using its associated builder.
     ///
-    /// Note that unline [CatalogBuilder::add_builder()] this will also bind the
+    /// Note that unlike [CatalogBuilder::add_builder()] this will also bind the
     /// implementation to component's default interfaces.
     pub fn add<C: Component>(&mut self) -> &mut Self {
         C::register(self);
@@ -54,7 +54,7 @@ impl CatalogBuilder {
     pub fn add_builder<Bld, Impl>(&mut self, builder: Bld) -> &mut Self
     where
         Impl: 'static + Send + Sync,
-        Bld: TypedBuilder<Impl> + 'static,
+        Bld: TypedBuilder<Impl> + TypedBuilderInterfaceBinder + 'static,
     {
         let key = ImplTypeId(TypeId::of::<Impl>());
         if self.builders.contains_key(&key) {
@@ -78,6 +78,8 @@ impl CatalogBuilder {
                 builder,
             ),
         );
+
+        Bld::bind_interfaces(self);
 
         self
     }

--- a/dill/tests/tests/test_catalog.rs
+++ b/dill/tests/tests/test_catalog.rs
@@ -257,8 +257,8 @@ fn test_catalog_binds_interfaces_for_builder_with_impl_without_explicit_args() {
         }
     }
 
-    // NOTE: In this case it is more correct to write it like `.add::<AImpl>()`,
-    //       but for the sake of the test we use another `add_builder()` method
+    // NOTE: In this case it is more correct to use `.add::<AImpl>()`,
+    //       but for the sake of the test we use `add_builder()` method
     let catalog = CatalogBuilder::new().add_builder(AImpl::builder()).build();
 
     let a_impl = catalog.get_one::<AImpl>().unwrap();


### PR DESCRIPTION
### Motivation

In a recent PR (https://github.com/kamu-data/kamu-cli/pull), I was required to write the following:
```rust
// src/infra/core/src/services/search/search_service_remote_impl.rs

#[dill::component]
#[dill::interface(dyn SearchServiceRemote)]
pub struct SearchServiceRemoteImpl {
    remote_repo_reg: Arc<dyn RemoteRepositoryRegistry>,
    odf_server_access_token_resolver: Arc<dyn odf::dataset::OdfServerAccessTokenResolver>,

    #[dill::component(explicit)]
    maybe_s3_metrics: Option<Arc<S3Metrics>>,
}

// app.rs

b.add_builder(SearchServiceRemoteImpl::builder(None))
    .bind::<dyn SearchServiceRemote, SearchServiceRemoteImpl>();
```

Since, at the registration stage (`add_builder()` call), we already know all the interfaces that will be there, I decided to try to remove the need for duplication.